### PR TITLE
Fixed docker setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,36 +33,42 @@ We recommend installing the Spotlight dashboard as a Docker instance on the targ
 
 2. In your working folder, create a new file: `docker-compose.yml`
 
+    ```yaml
+db:
+  image: postgres
+api:
+  image: pivotalsingapore/spotlight-rails
+  command: bin/rails server
+  env_file: docker_env
+  links:
+    - db
+web:
+  image: pivotalsingapore/spotlight-dashboard
+  env_file: docker_env
+  ports:
+    - "3030:80"
+  links:
+    - api
+  ```
+
+3. Rename `docker_env.sample` to `docker_env` and edit your configuration as necessary:
+
 	```yaml
-	db:
-	  image: postgres
-	api:
-	  image: pivotalsingapore/spotlight-rails
-	  command: bundle exec foreman start
-	  environment:
-	    - SECRET_KEY_BASE=<change_me!>
-	    - WEB_HOST=/
-	    - GOOGLE_API_CLIENT_ID=<change_me!>
-	    - GOOGLE_API_CLIENT_SECRET=<change_me!>
-	  links:
-	    - db
-	web:
-	  image: pivotalsingapore/spotlight-dashboard
-	  ports:
-	    - "3030:80"
-	  links:
-	    - api
+SECRET_KEY_BASE=<change_me!>
+WEB_HOST=/
+GOOGLE_API_CLIENT_ID=<change_me!>
+GOOGLE_API_CLIENT_SECRET=<change_me!>
 ```
 
-	***Remember to add your own `SECRET_KEY_BASE`.***
+***Remember to add your own `SECRET_KEY_BASE`.***
 
 ### Starting the Spotlight Docker instance
 
 1. Run the following command:
 
 	```
+docker-compose run --rm api rake db:create db:migrate
 docker-compose up -d
-docker-compose run --rm web rake db:create db:migrate
 ```
 
 2. You can now access the dashboard via the container IP address (e.g. `http://192.168.99.100:3030`).


### PR DESCRIPTION
## Fix: Broken Docker instructions.

The `docker` instructions in the README is broken and the docker image will fail to start, because of this line:

`docker-compose run --rm web rake db:create db:migrate`

the command above will fail. It should instead be:

`docker-compose run --rm api rake db:create db:migrate`

as the migrations should be run against `api`, not `web`.

I've also updated the `docker-compose.yml` file to reflect the changes to the file:

[x] change `environment` to `env_file`
[x] add `docker_env` instructions